### PR TITLE
change localhost to 127.0.0.1 everywhere

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -24,7 +24,7 @@ class UserInterface(BoxLayout):
 
     def _get_user_data(self) -> None:
         req = UrlRequest(
-            'http://localhost:8000/user/',
+            'http://127.0.0.1:8000/user/',
             on_success=self._unpack_user_data
         )
         req.wait(0)
@@ -47,7 +47,7 @@ class UserInterface(BoxLayout):
 
     def _get_new_quest(self) -> None:
         req = UrlRequest(
-            'http://localhost:8000/newquest/',
+            'http://127.0.0.1:8000/newquest/',
             on_success=self._unpack_user_data
         )
         req.wait(0)
@@ -60,7 +60,7 @@ class UserInterface(BoxLayout):
             )
         self._image.texture.flip_vertical()
         req = UrlRequest(
-            'http://localhost:8000/score/',
+            'http://127.0.0.1:8000/score/',
             req_headers={'Content-Type': 'application/json'},
             req_body=json.dumps({
                 'mode': 'RGB',


### PR DESCRIPTION
Using `localhost` is only an issue when I run the server on Windows. The code before this merge runs fine on MacOS.

I'm not super sure why I observe this behavior. I'll leave behind these links for me to play whack-a-mole with later.

https://stackoverflow.com/questions/70138815/fastapi-responding-slowly-when-calling-through-other-python-app-but-fast-in-cur
https://stackoverflow.com/questions/9243221/does-node-js-perform-badly-on-windows-surely-it-cant-be-slower-than-apache-for/9244784#9244784

https://serverfault.com/questions/1040302/windows-10-localhost-resolution-slow
https://superuser.com/questions/436574/ipv4-vs-ipv6-priority-in-windows-7/436944#436944